### PR TITLE
Use a temporary url for private uploads

### DIFF
--- a/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -2,6 +2,7 @@
 
 namespace Filament\Forms\Components;
 
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use SplFileInfo;
@@ -111,12 +112,21 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
     protected function handleUploadedFileUrlRetrieval($file): ?string
     {
+        $storage = $this->getDisk();
+
         if (! $this->getModel()) {
             return null;
         }
 
         if ($file instanceof SplFileInfo) {
             return null;
+        }
+
+        if (
+            $storage->getDriver()->getAdapter() instanceof AwsS3Adapter &&
+            $this->getVisibility() === 'private'
+        ) {
+            return Media::findByUuid($file)?->getTemporaryUrl(now()->addMinutes(5));
         }
 
         return Media::findByUuid($file)?->getUrl();


### PR DESCRIPTION
If we upload a private file to S3 we should use a signed temporary URL for the preview to work.

See: https://github.com/laravel-filament/filament/blob/fca0ea26c1166ce405c5e8eda12dea85a3900282/packages/forms/src/Components/FileUpload.php#L471