### PR TITLE
add customProperties to support folders in zip file

### DIFF
--- a/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -88,6 +88,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $media = $mediaAdder
                 ->usingFileName($filename)
                 ->usingName($component->getMediaName() ?? '')
+                ->withCustomProperties($component->getCustomProperties())
                 ->toMediaCollection($component->getCollection(), $component->getDiskName());
 
             return $media->getAttributeValue('uuid');

--- a/src/Forms/Components/SpatieMediaLibraryFileUpload.php
+++ b/src/Forms/Components/SpatieMediaLibraryFileUpload.php
@@ -18,6 +18,8 @@ class SpatieMediaLibraryFileUpload extends FileUpload
 
     protected string | Closure | null $mediaName = null;
 
+    protected array $customProperties = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -125,6 +127,13 @@ class SpatieMediaLibraryFileUpload extends FileUpload
         return $this;
     }
 
+    public function customProperties(array $customProperties)
+    {
+        $this->customProperties = $properties;
+
+        return $this;
+    }
+
     public function getCollection(): string
     {
         return $this->evaluate($this->collection) ?? 'default';
@@ -133,6 +142,11 @@ class SpatieMediaLibraryFileUpload extends FileUpload
     public function getConversion(): ?string
     {
         return $this->evaluate($this->conversion);
+    }
+
+    public function getCustomProperties(): array
+    {
+        return $this->customProperties;
     }
 
     public function mediaName(string | Closure | null $name): static

--- a/src/Forms/Components/SpatieMediaLibraryMultipleFileUpload.php
+++ b/src/Forms/Components/SpatieMediaLibraryMultipleFileUpload.php
@@ -11,8 +11,6 @@ class SpatieMediaLibraryMultipleFileUpload extends MultipleFileUpload
 {
     protected string | Closure | null $collection = null;
 
-    protected array $customProperties = [];
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -23,13 +21,6 @@ class SpatieMediaLibraryMultipleFileUpload extends MultipleFileUpload
     public function collection(string | Closure | null $collection): static
     {
         $this->collection = $collection;
-
-        return $this;
-    }
-
-    public function customProperties(array $customProperties)
-    {
-        $this->customProperties = $customProperties;
 
         return $this;
     }

--- a/src/Forms/Components/SpatieMediaLibraryMultipleFileUpload.php
+++ b/src/Forms/Components/SpatieMediaLibraryMultipleFileUpload.php
@@ -30,11 +30,6 @@ class SpatieMediaLibraryMultipleFileUpload extends MultipleFileUpload
         return $this->evaluate($this->collection) ?? 'default';
     }
 
-    public function getCustomProperties(): array
-    {
-        return $this->customProperties;
-    }
-
     public function getUploadComponent(): Component
     {
         /** @var SpatieMediaLibraryFileUpload $component */

--- a/src/Forms/Components/SpatieMediaLibraryMultipleFileUpload.php
+++ b/src/Forms/Components/SpatieMediaLibraryMultipleFileUpload.php
@@ -11,6 +11,8 @@ class SpatieMediaLibraryMultipleFileUpload extends MultipleFileUpload
 {
     protected string | Closure | null $collection = null;
 
+    protected array $customProperties = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -25,9 +27,21 @@ class SpatieMediaLibraryMultipleFileUpload extends MultipleFileUpload
         return $this;
     }
 
+    public function customProperties(array $customProperties)
+    {
+        $this->customProperties = $customProperties;
+
+        return $this;
+    }
+
     public function getCollection(): ?string
     {
         return $this->evaluate($this->collection) ?? 'default';
+    }
+
+    public function getCustomProperties(): array
+    {
+        return $this->customProperties;
     }
 
     public function getUploadComponent(): Component


### PR DESCRIPTION
Hi,

I don't think my PR is correct but it's an attempt. Feel free to correct it.

So I am trying to add custom properties to support folders in my zip files. In spatie media library docs it is this section

https://spatie.be/docs/laravel-medialibrary/v10/advanced-usage/using-custom-properties#content-zip-file-folders

```php
// Example 1
$mediaItem = Media::find($id);

$mediaItem->setCustomProperty('zip_filename_prefix', 'folder/subfolder/'); // stores $mediaItem in folder/subfolder/

$mediaItem->save();

$mediaStream =  MediaStream::create('export.zip');
$mediaStream->addMedia($mediaItem);

// Example 2
$book->addMedia($photo)
                ->withCustomProperties(['zip_filename_prefix' => 'author/'])
                ->toMediaCollection('author-photos');
```



