### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
             "Filament\\": "src"
         }
     },
+    "conflict": {
+        "filament/filament": "<4.0.0"
+    },
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
if a dev accidentally installs v3 of the media-library plugin along with  filament/filament v4, it breaks in hard-to-understand ways.

https://github.com/filamentphp/filament/issues/16806 got me, too, where images would just not save correctly.

adding conflict will, I believe, prevent that from happening by forcing v4.